### PR TITLE
Optimize SQL queries and object instantiation with caching

### DIFF
--- a/django_prbac/decorators.py
+++ b/django_prbac/decorators.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, absolute_import, print_function
 # Local Imports
 from django.http import Http404
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 
 
 def requires_privilege(slug, **assignment):
@@ -17,7 +17,8 @@ def requires_privilege(slug, **assignment):
         (in a parameterized fashion)
         """
         def wrapped(request, *args, **kwargs):
-            ensure_request_has_privilege(request, slug, **assignment)
+            if not has_privilege(request, slug, **assignment):
+                raise PermissionDenied()
             return fn(request, *args, **kwargs)
 
         return wrapped
@@ -32,9 +33,8 @@ def requires_privilege_raise404(slug, **assignment):
     """
     def decorate(fn):
         def wrapped(request, *args, **kwargs):
-            try:
-                return requires_privilege(slug, **assignment)(fn)(request, *args, **kwargs)
-            except PermissionDenied:
+            if not has_privilege(request, slug, **assignment):
                 raise Http404()
+            return decorated(request, *args, **kwargs)
         return wrapped
     return decorate

--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -316,3 +316,6 @@ class DictCache(object):
 
     def set(self, key, value):
         self.data[key] = (value, time.time() + self.timeout)
+
+    def clear(self):
+        self.data.clear()

--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -129,7 +129,7 @@ class Role(ValidatingModel, models.Model):
         if roles is None or self.id not in roles:
             self.update_cache()
             roles = cache.get(self.ROLES_BY_ID)
-        return roles[self.id]
+        return roles.get(self.id, self)
 
     def get_privileges(self, assignment):
         if not assignment:

--- a/django_prbac/tests/test_decorators.py
+++ b/django_prbac/tests/test_decorators.py
@@ -8,11 +8,13 @@ from django.http import HttpRequest
 # Local imports
 from django_prbac.decorators import requires_privilege
 from django_prbac.exceptions import PermissionDenied
+from django_prbac.models import Role
 from django_prbac import arbitrary
 
 class TestDecorators(TestCase):
 
     def setUp(self):
+        Role.get_cache().clear()
         self.zazzle_privilege = arbitrary.role(slug=arbitrary.unique_slug('zazzle'), parameters=set(['domain']))
 
     def test_requires_privilege_no_current_role(self):
@@ -89,5 +91,3 @@ class TestDecorators(TestCase):
         request = HttpRequest()
         request.role = requestor_role.instantiate({})
         view(request)
-
-

--- a/django_prbac/tests/test_models.py
+++ b/django_prbac/tests/test_models.py
@@ -15,6 +15,9 @@ from django_prbac import arbitrary
 
 class TestRole(TestCase):
 
+    def setUp(self):
+        Role.get_cache().clear()
+
     def test_has_permission_immediate_no_params(self):
         subrole = arbitrary.role()
         superrole1 = arbitrary.role()
@@ -101,6 +104,9 @@ class TestGrant(TestCase):
 
 class TestUserRole(TestCase):
 
+    def setUp(self):
+        Role.get_cache().clear()
+
     def test_user_role_integration(self):
         """
         Basic smoke test of integration of PRBAC with django.contrib.auth
@@ -111,7 +117,7 @@ class TestUserRole(TestCase):
         arbitrary.grant(from_role=role, to_role=priv)
         user_role = arbitrary.user_role(user=user, role=role)
 
-        self.assertEquals(user.prbac_role, user_role)
+        self.assertEqual(user.prbac_role, user_role)
         self.assertTrue(user.prbac_role.has_privilege(role))
         self.assertTrue(user.prbac_role.has_privilege(priv))
 

--- a/django_prbac/tests/test_models.py
+++ b/django_prbac/tests/test_models.py
@@ -83,6 +83,13 @@ class TestRole(TestCase):
         self.assertFalse(subrole.instantiate({}).has_privilege(superrole1.instantiate(dict(one='baz'))))
 
 
+    def test_unsaved_role_does_not_have_permission(self):
+        role1 = Role()
+        role2 = arbitrary.role()
+        self.assertFalse(role1.has_privilege(role2))
+        self.assertFalse(role2.has_privilege(role1))
+
+
 class TestGrant(TestCase):
 
     def test_instantiated_to_role_smoke_test(self):

--- a/django_prbac/utils.py
+++ b/django_prbac/utils.py
@@ -14,11 +14,10 @@ def has_privilege(request, slug, **assignment):
     if not hasattr(request, 'role'):
         return False
 
-    roles = Role.objects.filter(slug=slug)
-    if not roles:
+    privilege = Role.get_privilege(slug, assignment)
+    if privilege is None:
         return False
 
-    privilege = roles[0].instantiate(assignment)
     if request.role.has_privilege(privilege):
         return True
 

--- a/django_prbac/utils.py
+++ b/django_prbac/utils.py
@@ -1,5 +1,6 @@
 # Use modern Python
 from __future__ import unicode_literals, absolute_import, print_function
+import warnings
 
 # Local Imports
 from django_prbac.exceptions import PermissionDenied
@@ -34,9 +35,11 @@ def has_privilege(request, slug, **assignment):
 def ensure_request_has_privilege(request, slug, **assignment):
     """
     DEPRECATED
-
-    You most likely want `has_permission` or one of the
-    `requires_privilege` decorators.
     """
+    warnings.warn(
+        '`ensure_request_has_privilege` is deprecated. You likely want '
+        '`has_permission` or one of the `requires_privilege` decorators',
+        DeprecationWarning
+    )
     if not has_privilege(request, slug, **assignment):
         raise PermissionDenied()


### PR DESCRIPTION
Review commits individually. This should be fully backward compatible, and adds a caching layer that can reduce the number of SQL queries from 100s per request (depending on the number of roles and grants) to 2 per cache interval (defaults to 60 seconds). All roles and grants are cached in memory.

@esoergel @biyeun cc @sravfeyn 