### PR TITLE
Mysql compatibilty

### DIFF
--- a/django_prbac/migrations/0001_initial.py
+++ b/django_prbac/migrations/0001_initial.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 import django_prbac.fields
 from django.conf import settings
 import json_field.fields
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             name='Role',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('slug', models.CharField(help_text='The formal slug for this role, which should be unique', unique=True, max_length=256)),
+                ('slug', models.CharField(help_text='The formal slug for this role, which should be unique', unique=True, max_length=255)),
                 ('name', models.CharField(help_text='The friendly name for this role to present to users; this need not be unique.', max_length=256)),
                 ('description', models.TextField(default='', help_text='A long-form description of the intended semantics of this role.', blank=True)),
                 ('parameters', django_prbac.fields.StringSetField(default=set, help_text='A set of strings which are the parameters for this role. Entered as a JSON list.', blank=True)),

--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -46,7 +46,7 @@ class Role(ValidatingModel, models.Model):
     # ---------------
 
     slug = models.CharField(
-        max_length=256,
+        max_length=255,
         help_text='The formal slug for this role, which should be unique',
         unique=True,
     )


### PR DESCRIPTION
Currently prbac is not compatible with Mysql since it attempts to create an index on char field that is above 255 characters which hits a Mysql limitation.

Note that this change requires modification to existing migrations else one cannot setup a DB on Mysql at all. I ignored the South migrations since they will be invalidated by such a change.

I'm guessing such a change cant really be merged into master so this PR might just be for discussion.
