### PR TITLE
Remove test imports for django test runner

### DIFF
--- a/django_prbac/tests/__init__.py
+++ b/django_prbac/tests/__init__.py
@@ -1,4 +1,0 @@
-from .test_fields import *
-from .test_forms import *
-from .test_decorators import *
-from .test_models import *


### PR DESCRIPTION
~~This may break the local travis tests. Not sure of the best solution. Maybe exclude `submodules/django-prbac-src` when running HQ tests?~~ Looks like it's all good.

@proteusvacuum 