### PR TITLE
Remove usage of deprecated _get_val_from_obj in django 2.0+

### DIFF
--- a/django_prbac/fields.py
+++ b/django_prbac/fields.py
@@ -49,7 +49,7 @@ class StringListField(models.TextField):
             return django_prbac.csv.line_to_string(value, lineterminator='')
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
     def formfield(self, **kwargs):
@@ -99,7 +99,7 @@ class StringSetField(StringListField):
         return set(value)
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
     def get_prep_value(self, value):


### PR DESCRIPTION
Hi and thanks for this great work,

Here is a small PR that removes usage of the deprecated method `_get_val_from_obj` in Django 2.0+

Would you mind having this a look ?