### PR TITLE
Python3 str repr

### DIFF
--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -8,6 +8,7 @@ import weakref
 # Django imports
 from django.db import models
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
 
 # External Library imports
 import jsonfield
@@ -31,6 +32,7 @@ class ValidatingModel(object):
         super(ValidatingModel, self).save(force_insert, force_update, **kwargs)
 
 
+@python_2_unicode_compatible
 class Role(ValidatingModel, models.Model):
     """
     A PRBAC role, aka a Role parameterized by a set of named variables. Roles
@@ -181,7 +183,7 @@ class Role(ValidatingModel, models.Model):
     def __repr__(self):
         return 'Role(%r, parameters=%r)' % (self.slug, self.parameters)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s (%s)' % (self.name, self.slug)
 
 


### PR DESCRIPTION
This makes assigning roles easier in the Admin panel. Currently in python3 only `Role(<id>)` is shown since `__unicode__` is not called in python3. According to this: https://docs.djangoproject.com/en/1.10/topics/python3/#str-and-unicode-methods, this is the way you get it to work in both worlds. Works for me in python3, haven't tested in python2

@millerdev 