### PR TITLE
Comment about CVE-2019-19118

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
+        # avoid django>=2.1.0,<2.1.5 due to CVE-2019-19118
+        # https://github.com/advisories/GHSA-hvmf-r92r-27hr
         'django>=1.8,<2.1',
         'jsonfield>=1.0.3',
         'simplejson',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        # avoid django>=2.1.0,<2.1.15 due to CVE-2019-19118
+        # avoid django>=2.1.0,<2.1.15,>=2.2.0,<2.2.8 due to CVE-2019-19118
         # https://github.com/advisories/GHSA-hvmf-r92r-27hr
         'django>=1.8,<2.1',
         'jsonfield>=1.0.3',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        # avoid django>=2.1.0,<2.1.5 due to CVE-2019-19118
+        # avoid django>=2.1.0,<2.1.15 due to CVE-2019-19118
         # https://github.com/advisories/GHSA-hvmf-r92r-27hr
         'django>=1.8,<2.1',
         'jsonfield>=1.0.3',


### PR DESCRIPTION
The CVE does not apply here because this project currently requires `django>=1.8,<2.1` and the vulnerable versions are `>= 2.1.0, < 2.1.5`.