### PR TITLE
Update build process to use pyproject.toml & pep517.build

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,0 +1,48 @@
+# Releasing on PyPI
+
+We follow https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+(Oct 2019 version).
+
+
+## One-time setup
+
+Make sure your `~/.pypirc` is set up like this
+
+```bash
+[distutils]
+index-servers=
+    pypi
+    test
+
+[test]
+repository = https://test.pypi.org/legacy/
+username = <your test user name goes here>
+
+[pypi]
+username = __token__
+```
+
+## Build
+```bash
+rm -rf build dist
+python -m pep517.build .
+```
+
+## Push to PyPI staging server
+
+```bash
+twine upload -r test --sign dist/*
+```
+
+In a different virtualenv, test that you can install it:
+
+```bash
+pip install -i https://testpypi.python.org/pypi django-prbac --upgrade
+```
+
+
+## Push to PyPI
+
+```bash
+twine upload -r pypi --sign dist/*
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-universal=1
-
-[metadata]
-license_file=LICENSE

--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    options={"bdist_wheel": {"universal": "1"}},
 )


### PR DESCRIPTION
What https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/ recommends as of Oct 2019. Document the build process in PYPI_README.md.

This hadn't been built in a while, so rather than try to piece together how to build it as is, I updated to the latest recommendations in that article. (The old setup I believe was from an older version of that article.)