### PR TITLE
Add support for Django 4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        django-version: [ "3.2.*", "4.2.*" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install dependencies
         run: |
-          pip install django==3.2.* 
+          pip install django==${{ matrix.django-version }}
           pip install -e .
           pip install coverage coveralls
       - name: run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           pip install coverage coveralls
       - name: run tests
         run: |
-          coverage run --source='django_prbac' `which django-admin.py` test django_prbac --settings django_prbac.mock_settings --traceback
+          coverage run --source='django_prbac' `which django-admin` test django_prbac --settings django_prbac.mock_settings --traceback
       - name: report coverage stats
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,61 @@
-.python-version
+*.py[cod]
+*~
+\#*
+.\#*
+.history
+.mypy_cache
+.vscode
 
-.coverage
+# README.txt is just for the Cheeseshop; README.md is the authoritative one
+/README.txt
+/commcare_export/VERSION
 
+# OSX droppings
+.DS_Store
+
+# C extensions
+*.so
+
+# Packages
+*.egg
 *.egg-info
-__pycache__/
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+/pip-wheel-metadata
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# PyCharm
+.idea
+
+# Excel
+~*.xlsx
+
+/docs/_build
+/django-prbac.db
+
+# virtualenv
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,58 +1,6 @@
-*.py[cod]
-*~
-\#*
-.\#*
-.history
-.mypy_cache
-.vscode
+.python-version
 
-# README.txt is just for the Cheeseshop; README.md is the authoritative one
-/README.txt
-/commcare_export/VERSION
-
-# OSX droppings
-.DS_Store
-
-# C extensions
-*.so
-
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
-.installed.cfg
-lib
-lib64
-/pip-wheel-metadata
-
-# Installer logs
-pip-log.txt
-
-# Unit test / coverage reports
 .coverage
-.tox
-nosetests.xml
 
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# PyCharm
-.idea
-
-# Excel
-~*.xlsx
-
-/docs/_build
-/django-prbac.db
+*.egg-info
+__pycache__/

--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -145,11 +145,11 @@ class Role(ValidatingModel, models.Model):
             except AttributeError:
                 pass
         try:
-            return [membership.instantiated_to_role(assignment)
-                    for membership in self.memberships_granted.all()]
+            memberships = self.memberships_granted.all()
         except ValueError:
             # Django 4 raises ValueError if fk relationship is accessed prior to save
             return []
+        return [m.instantiated_to_role(assignment) for m in memberships]
 
     def instantiate(self, assignment):
         """

--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -144,8 +144,12 @@ class Role(ValidatingModel, models.Model):
                 return self._granted_privileges
             except AttributeError:
                 pass
-        return [membership.instantiated_to_role(assignment)
-                for membership in self.memberships_granted.all()]
+        try:
+            return [membership.instantiated_to_role(assignment)
+                    for membership in self.memberships_granted.all()]
+        except ValueError:
+            # Django 4 raises ValueError if fk relationship is accessed prior to save
+            return []
 
     def instantiate(self, assignment):
         """

--- a/django_prbac/tests/test_models.py
+++ b/django_prbac/tests/test_models.py
@@ -71,10 +71,16 @@ class TestRole(TestCase):
         self.assertFalse(subrole.instantiate({}).has_privilege(superrole1.instantiate(dict(one='baz'))))
 
     def test_unsaved_role_does_not_have_permission(self):
+        import django
         role1 = Role()
         role2 = arbitrary.role()
-        self.assertFalse(role1.has_privilege(role2))
-        self.assertFalse(role2.has_privilege(role1))
+        if django.VERSION >= (4, 0):
+            with self.assertRaises(ValueError):
+                self.assertFalse(role1.has_privilege(role2))
+                self.assertFalse(role2.has_privilege(role1))
+        else:
+            self.assertFalse(role1.has_privilege(role2))
+            self.assertFalse(role2.has_privilege(role1))
 
 
 class TestGrant(TestCase):

--- a/django_prbac/tests/test_models.py
+++ b/django_prbac/tests/test_models.py
@@ -71,16 +71,10 @@ class TestRole(TestCase):
         self.assertFalse(subrole.instantiate({}).has_privilege(superrole1.instantiate(dict(one='baz'))))
 
     def test_unsaved_role_does_not_have_permission(self):
-        import django
         role1 = Role()
         role2 = arbitrary.role()
-        if django.VERSION >= (4, 0):
-            with self.assertRaises(ValueError):
-                self.assertFalse(role1.has_privilege(role2))
-                self.assertFalse(role2.has_privilege(role1))
-        else:
-            self.assertFalse(role1.has_privilege(role2))
-            self.assertFalse(role2.has_privilege(role1))
+        self.assertFalse(role1.has_privilege(role2))
+        self.assertFalse(role2.has_privilege(role1))
 
 
 class TestGrant(TestCase):

--- a/django_prbac/urls.py
+++ b/django_prbac/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        # avoid django 2 <2.2.10 and django 3 < 3.0.7
+        # avoid django 3 < 3.0.7
         # https://github.com/advisories/GHSA-hmr4-m2h5-33qx
-        'django>=2.2.13,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,!=3.0.4,!=3.0.5,!=3.0.6,<4',
+        'django>=3.0.7,<5',
         'jsonfield>=1.0.3,<4',
         'simplejson',
     ],
@@ -45,9 +45,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     options={"bdist_wheel": {"universal": "1"}},


### PR DESCRIPTION
Python 3.7 has been EOLed, so remove that and run against newer versions of Python as well (3.10 and 3.11).

And in anticipation for Django 3.2 being EOLed in April 2024, we should update tests to run against both 3.2 and 4.2 LTS.