### PR TITLE
Add .readthedocs.yml configuration and tweak test option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,10 @@ jobs:
     needs: [configure]
     runs-on: ubuntu-22.04
     strategy:
+      # coveralls frequently fails with 500 errors, retrying usually helps.
+      # The default fail-fast=true would stop the running jobs on the first
+      # failure, which can make it harder to get all jobs passing.
+      fail-fast: false
       matrix:
         python: ${{ fromJSON(needs.configure.outputs.python_versions) }}
         django: ${{ fromJSON(needs.configure.outputs.django_versions) }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
The docs build has been failing for a few years now. This config change fixes it. Tested by adding a hidden build branch on readthedocs.

:blowfish: Review by commit.