### PR TITLE
fix: add __hash__ to UserRole model to prevent TypeError on delete

### DIFF
--- a/django_prbac/models.py
+++ b/django_prbac/models.py
@@ -259,6 +259,9 @@ class UserRole(ValidatingModel, models.Model):
     def has_privilege(self, privilege):
         return self.role.has_privilege(privilege)
 
+    def __hash__(self):
+        return hash(self.user_id) ^ hash(self.role_id)
+
     def __eq__(self, other):
         return self.user == other.user and self.role == other.role
 


### PR DESCRIPTION
UserRole defines __eq__ without __hash__, causing instances to be unhashable in Python. This triggers TypeError when Django's deletion collector attempts to add UserRole instances to a set during cascade delete operations.